### PR TITLE
Add go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd h1:+iAPaTbi1gZpcpDwe/BW1fx7Xoesv69hLNGPheoyhBs=
+github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd/go.mod h1:4soZNh0zW0LtYGdQ416i0jO0EIqMGcbtaspRS4BDvRQ=


### PR DESCRIPTION
As is, building the snap results in 

```
$ snapcraft --destructive-mode

Pulling daemon 
+ snapcraftctl pull
Building daemon 
+ snapcraftctl build
+ go mod download
+ go install -p 8 -ldflags -linkmode=external ./...
daemon-notify/main.go:8:2: missing go.sum entry for module providing package github.com/okzk/sdnotify (imported by github.com/knitzsche/test-notify/daemon-notify); to add:
        go get github.com/knitzsche/test-notify/daemon-notify
Failed to build 'daemon'.

Recommended resolution:
Check the build logs and ensure the part's configuration and sources are correct.
```
Adding the go.sum fixes that